### PR TITLE
Add C Bandit environment

### DIFF
--- a/pufferlib/ocean/bandit/bandit.h
+++ b/pufferlib/ocean/bandit/bandit.h
@@ -1,0 +1,120 @@
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "raylib.h"
+
+const Color PUFF_RED = (Color){187, 0, 0, 255};
+const Color PUFF_CYAN = (Color){0, 187, 187, 255};
+const Color PUFF_WHITE = (Color){241, 241, 241, 241};
+const Color PUFF_BACKGROUND = (Color){6, 24, 24, 255};
+
+double randn(double mean, double std) {
+    static int has_spare = 0;
+    static double spare;
+    if (has_spare) {
+        has_spare = 0;
+        return mean + std * spare;
+    }
+    has_spare = 1;
+    double u, v, s;
+    do {
+        u = 2.0 * rand() / RAND_MAX - 1.0;
+        v = 2.0 * rand() / RAND_MAX - 1.0;
+        s = u * u + v * v;
+    } while (s >= 1.0 || s == 0.0);
+    s = sqrt(-2.0 * log(s) / s);
+    spare = v * s;
+    return mean + std * (u * s);
+}
+
+typedef struct {
+    float score;
+    float n;
+} Log;
+
+typedef struct {
+    Log log;
+    float* observations;
+    int* actions;
+    float* rewards;
+    unsigned char* terminals;
+    int num_arms;
+    float reward_std;
+    float drift_std;
+    float* means;
+    float cumulative_reward;
+    int step;
+    float* history;
+    int history_len;
+} Bandit;
+
+void c_reset(Bandit* env) {
+    for (int i = 0; i < env->num_arms; i++) {
+        env->means[i] = randn(0.0, 1.0);
+    }
+    env->observations[0] = 1.0f;
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0;
+    env->cumulative_reward = 0.0f;
+    env->step = 0;
+    if (env->history_len > 0) {
+        memset(env->history, 0, sizeof(float) * env->history_len);
+    }
+}
+
+void add_log(Bandit* env) {
+    env->log.score += env->rewards[0];
+    env->log.n += 1.0f;
+}
+
+void c_step(Bandit* env) {
+    int action = env->actions[0];
+    if (action < 0 || action >= env->num_arms) {
+        env->rewards[0] = 0.0f;
+    } else {
+        env->rewards[0] = randn(env->means[action], env->reward_std);
+    }
+    env->cumulative_reward += env->rewards[0];
+    if (env->step < env->history_len) {
+        env->history[env->step] = env->cumulative_reward;
+    }
+    env->step += 1;
+    for (int i = 0; i < env->num_arms; i++) {
+        env->means[i] += randn(0.0, env->drift_std);
+    }
+    env->terminals[0] = 0;
+    add_log(env);
+}
+
+void c_render(Bandit* env) {
+    if (!IsWindowReady()) {
+        InitWindow(720, 480, "PufferLib Bandit");
+        SetTargetFPS(60);
+    }
+    if (IsKeyDown(KEY_ESCAPE)) {
+        exit(0);
+    }
+    BeginDrawing();
+    ClearBackground(PUFF_BACKGROUND);
+    DrawText(TextFormat("Total Reward: %.2f", env->cumulative_reward), 20, 20, 20, PUFF_WHITE);
+    int max_display = env->history_len < env->step ? env->history_len : env->step;
+    if (max_display > 1) {
+        float sx = 680.0f / (float)(max_display - 1);
+        for (int i = 1; i < max_display; i++) {
+            float x0 = 20 + sx * (i - 1);
+            float y0 = 460 - env->history[i - 1];
+            float x1 = 20 + sx * i;
+            float y1 = 460 - env->history[i];
+            DrawLine((int)x0, (int)y0, (int)x1, (int)y1, PUFF_CYAN);
+        }
+    }
+    EndDrawing();
+}
+
+void c_close(Bandit* env) {
+    free(env->means);
+    free(env->history);
+    if (IsWindowReady()) {
+        CloseWindow();
+    }
+}

--- a/pufferlib/ocean/bandit/bandit.py
+++ b/pufferlib/ocean/bandit/bandit.py
@@ -1,0 +1,39 @@
+"""Multi-Armed Bandit environment backed by C."""
+
+import gymnasium
+import numpy as np
+
+import pufferlib
+from pufferlib.ocean.bandit import binding
+
+class Bandit(pufferlib.PufferEnv):
+    def __init__(self, num_envs=1, render_mode=None, num_arms=4,
+            reward_std=1.0, drift_std=0.01, history_len=512, buf=None, seed=0):
+        self.single_observation_space = gymnasium.spaces.Box(low=0, high=1,
+            shape=(1,), dtype=np.float32)
+        self.single_action_space = gymnasium.spaces.Discrete(num_arms)
+        self.render_mode = render_mode
+        self.num_agents = num_envs
+
+        super().__init__(buf)
+        self.c_envs = binding.vec_init(self.observations, self.actions, self.rewards,
+            self.terminals, self.truncations, num_envs, seed,
+            num_arms=num_arms, reward_std=reward_std,
+            drift_std=drift_std, history_len=history_len)
+
+    def reset(self, seed=0):
+        binding.vec_reset(self.c_envs, seed)
+        return self.observations, []
+
+    def step(self, actions):
+        self.actions[:] = actions
+        binding.vec_step(self.c_envs)
+        info = [binding.vec_log(self.c_envs)]
+        return (self.observations, self.rewards,
+            self.terminals, self.truncations, info)
+
+    def render(self):
+        binding.vec_render(self.c_envs, 0)
+
+    def close(self):
+        binding.vec_close(self.c_envs)

--- a/pufferlib/ocean/bandit/binding.c
+++ b/pufferlib/ocean/bandit/binding.c
@@ -1,0 +1,23 @@
+#include "bandit.h"
+
+#define Env Bandit
+#include "../env_binding.h"
+
+static int my_init(Env* env, PyObject* args, PyObject* kwargs) {
+    env->num_arms = unpack(kwargs, "num_arms");
+    env->reward_std = unpack(kwargs, "reward_std");
+    env->drift_std = unpack(kwargs, "drift_std");
+    env->history_len = unpack(kwargs, "history_len");
+    if (env->history_len <= 0) {
+        env->history_len = 1024;
+    }
+    env->means = calloc(env->num_arms, sizeof(float));
+    env->history = calloc(env->history_len, sizeof(float));
+    c_reset(env);
+    return 0;
+}
+
+static int my_log(PyObject* dict, Log* log) {
+    assign_to_dict(dict, "score", log->score);
+    return 0;
+}

--- a/pufferlib/ocean/environment.py
+++ b/pufferlib/ocean/environment.py
@@ -67,10 +67,11 @@ def make_squared(distance_to_target=3, num_targets=1, buf=None, **kwargs):
     env = pufferlib.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf, **kwargs)
 
-def make_bandit(num_actions=10, reward_scale=1, reward_noise=1, buf=None):
-    from . import sanity
-    env = sanity.Bandit(num_actions=num_actions, reward_scale=reward_scale,
-        reward_noise=reward_noise)
+def make_bandit(num_arms=10, reward_std=1, drift_std=0.01, buf=None, **kwargs):
+    from .bandit import bandit
+    env = bandit.Bandit(num_envs=kwargs.get('num_envs', 1), render_mode=None,
+        num_arms=num_arms, reward_std=reward_std, drift_std=drift_std,
+        history_len=kwargs.get('history_len', 512), buf=buf, seed=kwargs.get('seed', 0))
     env = pufferlib.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
 
@@ -153,6 +154,7 @@ MAKE_FUNCTIONS = {
     'pacman': 'Pacman',
     'checkers': 'Checkers',
     'asteroids': 'Asteroids',
+    'bandit': 'Bandit',
     'spaces': make_spaces,
     'multiagent': make_multiagent,
 }

--- a/pufferlib/ocean/torch.py
+++ b/pufferlib/ocean/torch.py
@@ -1025,3 +1025,36 @@ class Drone(nn.Module):
 
         values = self.value(hidden)
         return logits, values
+
+class Bandit(nn.Module):
+    """Simple MLP policy for the C bandit environment."""
+
+    def __init__(self, env, hidden_size=32):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.is_continuous = False
+        self.net = nn.Sequential(
+            pufferlib.pytorch.layer_init(
+                nn.Linear(env.single_observation_space.shape[0], hidden_size)
+            ),
+            nn.ReLU(),
+        )
+        self.actor = pufferlib.pytorch.layer_init(
+            nn.Linear(hidden_size, env.single_action_space.n), std=0.01
+        )
+        self.value = pufferlib.pytorch.layer_init(nn.Linear(hidden_size, 1), std=1)
+
+    def forward(self, observations, state=None):
+        hidden = self.encode_observations(observations)
+        return self.decode_actions(hidden)
+
+    def forward_train(self, x, state=None):
+        return self.forward(x, state)
+
+    def encode_observations(self, observations, state=None):
+        return self.net(observations.float())
+
+    def decode_actions(self, hidden):
+        action = self.actor(hidden)
+        value = self.value(hidden)
+        return action, value


### PR DESCRIPTION
## Summary
- add new non-stationary bandit environment in C
- bind the environment with Python wrappers
- expose it through `environment.py`
- provide a simple neural network policy for bandit agents

## Testing
- `pip install numpy gymnasium psutil torch --extra-index-url https://download.pytorch.org/whl/cpu`
- `pip install gym==0.26.2`
- `pytest tests/test_env_binding.py::test_env_binding -q` *(fails: ImportError: cannot import name 'binding' from 'pufferlib.ocean.breakout')*

------
https://chatgpt.com/codex/tasks/task_e_6880545adfd0832e89160518fd6b4158