### PR TITLE
Add non-stationary bandit environment

### DIFF
--- a/pufferlib/ocean/bandit/bandit.h
+++ b/pufferlib/ocean/bandit/bandit.h
@@ -1,0 +1,108 @@
+#include <stdlib.h>
+#include <string.h>
+#include "raylib.h"
+
+#define MAX_HISTORY 1024
+
+typedef struct {
+    float score;
+    float n; // Required as last field for logging
+} Log;
+
+typedef struct {
+    Log log;                     // Required field
+    float* observations;         // Required field
+    int* actions;                // Required field
+    float* rewards;              // Required field
+    unsigned char* terminals;    // Required field
+
+    int k;                       // Number of arms
+    float* means;                // Reward probability per arm
+    float total_reward;          // Sum of rewards
+    float history[MAX_HISTORY];  // Reward history for rendering
+    int step;                    // Steps elapsed
+} Bandit;
+
+static inline float randf(){return (float)rand()/ (float)RAND_MAX;}
+
+void init(Bandit* env){
+    env->means = (float*)calloc(env->k, sizeof(float));
+    for(int i=0;i<env->k;i++) env->means[i] = 0.5f;
+    env->total_reward = 0.0f;
+    env->step = 0;
+    memset(env->history, 0, sizeof(env->history));
+}
+
+void c_reset(Bandit* env){
+    env->log = (Log){0};
+    for(int i=0;i<env->k;i++) env->means[i] = 0.5f;
+    env->total_reward = 0.0f;
+    env->step = 0;
+    env->observations[0] = 0.0f;
+    env->rewards[0] = 0.0f;
+    env->terminals[0] = 0;
+    memset(env->history, 0, sizeof(env->history));
+}
+
+void c_step(Bandit* env){
+    int action = env->actions[0];
+    if(action < 0) action = 0;
+    if(action >= env->k) action = env->k - 1;
+
+    for(int i=0;i<env->k;i++){
+        env->means[i] += (randf() - 0.5f) * 0.1f; // Drift
+        if(env->means[i] < 0.0f) env->means[i] = 0.0f;
+        if(env->means[i] > 1.0f) env->means[i] = 1.0f;
+    }
+
+    env->rewards[0] = randf() < env->means[action] ? 1.0f : 0.0f;
+    env->terminals[0] = 0;
+    env->total_reward += env->rewards[0];
+    if(env->step < MAX_HISTORY)
+        env->history[env->step] = env->total_reward;
+    env->log.score += env->rewards[0];
+    env->log.n += 1.0f;
+    env->step += 1;
+    env->observations[0] = 0.0f;
+}
+
+const Color PUFF_RED = (Color){187, 0, 0, 255};
+const Color PUFF_CYAN = (Color){0, 187, 187, 255};
+const Color PUFF_WHITE = (Color){241, 241, 241, 241};
+const Color PUFF_BACKGROUND = (Color){6, 24, 24, 255};
+
+void c_render(Bandit* env){
+    if(!IsWindowReady()){
+        InitWindow(600, 400, "PufferLib Bandit");
+        SetTargetFPS(60);
+    }
+    if(IsKeyDown(KEY_ESCAPE)) exit(0);
+
+    BeginDrawing();
+    ClearBackground(PUFF_BACKGROUND);
+
+    int width = GetScreenWidth();
+    int height = GetScreenHeight();
+    int count = env->step < MAX_HISTORY ? env->step : MAX_HISTORY;
+
+    float max_val = 1.0f;
+    for(int i=0;i<count;i++)
+        if(env->history[i] > max_val) max_val = env->history[i];
+
+    for(int i=1;i<count;i++){
+        float x1 = (i-1) * (float)width / (MAX_HISTORY-1);
+        float y1 = height - env->history[i-1]/max_val * height;
+        float x2 = i * (float)width / (MAX_HISTORY-1);
+        float y2 = height - env->history[i]/max_val * height;
+        DrawLine((int)x1, (int)y1, (int)x2, (int)y2, PUFF_CYAN);
+    }
+
+    DrawText(TextFormat("Total Reward: %.1f", env->total_reward), 20, 20, 20, PUFF_WHITE);
+    EndDrawing();
+}
+
+void c_close(Bandit* env){
+    if(IsWindowReady()) CloseWindow();
+    free(env->means);
+}
+

--- a/pufferlib/ocean/bandit/bandit.py
+++ b/pufferlib/ocean/bandit/bandit.py
@@ -1,0 +1,49 @@
+import gymnasium
+import numpy as np
+
+import pufferlib
+from pufferlib.ocean.bandit import binding
+
+class Bandit(pufferlib.PufferEnv):
+    def __init__(self, num_envs=1, k=10, render_mode=None, buf=None, seed=0):
+        self.single_observation_space = gymnasium.spaces.Box(
+            low=0.0, high=1.0, shape=(1,), dtype=np.float32
+        )
+        self.single_action_space = gymnasium.spaces.Discrete(k)
+        self.render_mode = render_mode
+        self.num_agents = num_envs
+
+        super().__init__(buf)
+        self.c_envs = binding.vec_init(
+            self.observations,
+            self.actions,
+            self.rewards,
+            self.terminals,
+            self.truncations,
+            num_envs,
+            seed,
+            k=k,
+        )
+        self.k = k
+
+    def reset(self, seed=0):
+        binding.vec_reset(self.c_envs, seed)
+        return self.observations, []
+
+    def step(self, actions):
+        self.actions[:] = actions
+        binding.vec_step(self.c_envs)
+        info = [binding.vec_log(self.c_envs)]
+        return (
+            self.observations,
+            self.rewards,
+            self.terminals,
+            self.truncations,
+            info,
+        )
+
+    def render(self):
+        binding.vec_render(self.c_envs, 0)
+
+    def close(self):
+        binding.vec_close(self.c_envs)

--- a/pufferlib/ocean/bandit/binding.c
+++ b/pufferlib/ocean/bandit/binding.c
@@ -1,0 +1,15 @@
+#include "bandit.h"
+
+#define Env Bandit
+#include "../env_binding.h"
+
+static int my_init(Env* env, PyObject* args, PyObject* kwargs){
+    env->k = (int)unpack(kwargs, "k");
+    init(env);
+    return 0;
+}
+
+static int my_log(PyObject* dict, Log* log){
+    assign_to_dict(dict, "score", log->score);
+    return 0;
+}

--- a/pufferlib/ocean/environment.py
+++ b/pufferlib/ocean/environment.py
@@ -67,12 +67,10 @@ def make_squared(distance_to_target=3, num_targets=1, buf=None, **kwargs):
     env = pufferlib.EpisodeStats(env)
     return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf, **kwargs)
 
-def make_bandit(num_actions=10, reward_scale=1, reward_noise=1, buf=None):
-    from . import sanity
-    env = sanity.Bandit(num_actions=num_actions, reward_scale=reward_scale,
-        reward_noise=reward_noise)
-    env = pufferlib.EpisodeStats(env)
-    return pufferlib.emulation.GymnasiumPufferEnv(env=env, buf=buf)
+def make_bandit(k=10, buf=None, **kwargs):
+    from .bandit.bandit import Bandit
+    env = Bandit(num_envs=kwargs.get('num_envs', 1), k=k, buf=buf)
+    return env
 
 def make_memory(mem_length=2, mem_delay=2, buf=None, **kwargs):
     from . import sanity
@@ -135,6 +133,7 @@ MAKE_FUNCTIONS = {
     'snake': 'Snake',
     'squared': 'Squared',
     'pysquared': 'PySquared',
+    'bandit': 'Bandit',
     'connect4': 'Connect4',
     'g2048': 'G2048',
     'terraform': 'Terraform',

--- a/pufferlib/ocean/torch.py
+++ b/pufferlib/ocean/torch.py
@@ -19,6 +19,33 @@ from pufferlib.pytorch import layer_init, _nativize_dtype, nativize_tensor
 import numpy as np
 
 
+class Bandit(nn.Module):
+    """Simple network for the bandit environment."""
+    def __init__(self, env, hidden_size=32, **kwargs):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.net = nn.Sequential(
+            layer_init(nn.Linear(1, hidden_size)),
+            nn.ReLU(),
+        )
+        self.actor = layer_init(nn.Linear(hidden_size, env.single_action_space.n), std=0.01)
+        self.value_fn = layer_init(nn.Linear(hidden_size, 1), std=1)
+
+    def forward(self, x, state=None):
+        hidden = self.encode_observations(x)
+        return self.decode_actions(hidden)
+
+    def forward_train(self, x, state=None):
+        return self.forward(x, state)
+
+    def encode_observations(self, observations, state=None):
+        batch = observations.shape[0]
+        return self.net(observations.view(batch, -1).float())
+
+    def decode_actions(self, hidden, state=None):
+        return self.actor(hidden), self.value_fn(hidden)
+
+
 class Boids(nn.Module):
     def __init__(self, env, cnn_channels=32, hidden_size=128, **kwargs):
         super().__init__()


### PR DESCRIPTION
## Summary
- implement `bandit` environment in C with drifting arm means
- wrap environment in Python
- provide simple network
- expose bandit through environment loader

## Testing
- `python setup.py build_ext --inplace --force`
- `python -m pufferlib.pufferl train puffer_bandit` *(fails: heavyball missing)*
- `python -m pufferlib.pufferl eval puffer_bandit` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6881a0cf91f8832ea8f44812013e5d8d